### PR TITLE
178151320 fix force value layout

### DIFF
--- a/src/components/main-view.scss
+++ b/src/components/main-view.scss
@@ -40,6 +40,23 @@
       .question-mark {
         font-size: 26px;
       }
+      .result {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        margin-bottom: 20px;
+
+        .result-label {
+          display: flex;
+          justify-content: flex-start;
+          width: 150px;
+        }
+        .force-value {
+          display: flex;
+          justify-content: flex-end;
+          width: 65px;
+        }
+      }
     }
 
     .buttons {

--- a/src/components/main-view.scss
+++ b/src/components/main-view.scss
@@ -62,7 +62,7 @@
     .buttons {
       text-align: center;
       position: relative;
-      bottom: -220px;
+      bottom: -180px;
 
       button {
         padding: 6px;

--- a/src/components/main-view.tsx
+++ b/src/components/main-view.tsx
@@ -61,10 +61,14 @@ export const MainView: React.FC<IProps> = ({ showForce, mode, saveToTable, clear
                   </div>
                 : mode === "venus"
                   ? <>
-                    <div className="label">Force between object 1 and Venus:</div>
-                    <ForceValue object1={object1} object2={object2} />
-                    <div className="label">Force between object 1 and Earth:</div>
-                    <ForceValue object1={object1} object2={object3} />
+                      <div className="result">
+                        <div className="result-label">Force between object 1 and Venus:</div>
+                        <ForceValue object1={object1} object2={object2} />
+                      </div>
+                      <div className="result">
+                        <div className="result-label">Force between object 1 and Earth:</div>
+                        <ForceValue object1={object1} object2={object3} />
+                      </div>
                     </>
                   : mode === "earth"
                     ? <ForceValue object1={object1} object2={object2} />

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -8,7 +8,7 @@ export const getMode = () => {
 export const getObjectOptions = (mode: Mode) => {
   const modeOptions = {
                             "earth": [ {object:"kite", text: "Kite"},
-                                       {object:"soccer", text:"Soccer"},
+                                       {object:"soccer", text:"Soccer Ball"},
                                        {object:"schoolbus", text:"School Bus"},
                                        {object:"worldTradeCtr", text:"One World Trade Center"}
                                       ],


### PR DESCRIPTION
Changes the layout of the force result column for the venus mode. Moved the buttons up so it doesn't overlap with the table. Buttons are now in a column instead of side by side to accomodate the width of Activity Player
Fixes the dropdown text from "Soccer" to "Soccer Ball"